### PR TITLE
Filter out metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+- alert on min server count
+- fixed reporting of empty values
 
 ## [0.0.4] - 2015-08-04
 ### Changed

--- a/bin/metrics-haproxy.rb
+++ b/bin/metrics-haproxy.rb
@@ -125,6 +125,10 @@ class HAProxyMetrics < Sensu::Plugin::Metric::CLI::Graphite
     return nil
   end
 
+  def output(*args)
+    super(*args) unless args[1].nil?
+  end
+
   def run #rubocop:disable all
     out = nil
     1.upto(config[:retries]) do |_i|


### PR DESCRIPTION
Filter out invalid metrics to prevent the following warnings from influxdb:

[graphite] 2015/10/26 19:50:33 unable to parse line: received "server1.haproxy.amqp.response_1xx" which doesn't have required fields
