### PR TITLE
-b and -B flags to check session availability per backend

### DIFF
--- a/bin/check-haproxy.rb
+++ b/bin/check-haproxy.rb
@@ -137,14 +137,14 @@ class CheckHAProxy < Sensu::Plugin::Check::CLI
       critical_backends = services.select do |svc|
         config[:backend_session_crit_percent] &&
         svc[:svname] == 'BACKEND' &&
-        svc[:slim].to_i > 0 &&
+        svc[:smax].to_i > 0 &&
         (100 * svc[:scur].to_f / svc[:smax].to_f) > config[:backend_session_crit_percent]
       end
 
       warning_backends = services.select do |svc|
         config[:backend_session_warn_percent] &&
         svc[:svname] == 'BACKEND' &&
-        svc[:slim].to_i > 0 &&
+        svc[:smax].to_i > 0 &&
         (100 * svc[:scur].to_f / svc[:smax].to_f) > config[:backend_session_warn_percent]
       end
 
@@ -157,16 +157,16 @@ class CheckHAProxy < Sensu::Plugin::Check::CLI
         critical status + '; Active sessions critical: ' + critical_sessions.map { |s| "#{s[:scur]} #{s[:pxname]}.#{s[:svname]}" }.join(', ')
       elsif config[:backend_session_crit_percent] && !critical_backends.empty?
         critical status + '; Active backends critical: ' +
-          critical_backends.map { |s| "current sessions: #{s[:scur]}, maximum sessions: #{s[:slim]} for #{s[:pxname]} backend." }.join(', ')
+          critical_backends.map { |s| "current sessions: #{s[:scur]}, maximum sessions: #{s[:smax]} for #{s[:pxname]} backend." }.join(', ')
       elsif services.size < config[:min_warn_count]
         warning status
       elsif percent_up < config[:warn_percent]
         warning status
-      elsif !warning_sessions.empty? && config[:backend_session_warning_percent].nil?
+      elsif !warning_sessions.empty? && config[:backend_session_warn_percent].nil?
         warning status + '; Active sessions warning: ' + warning_sessions.map { |s| "#{s[:scur]} #{s[:pxname]}.#{s[:svname]}" }.join(', ')
       elsif config[:backend_session_warn_percent] && !warning_backends.empty?
         critical status + '; Active backends warning: ' +
-          warning_backends.map { |s| "current sessions: #{s[:scur]}, maximum sessions: #{s[:slim]} for #{s[:pxname]} backend." }.join(', ')
+          warning_backends.map { |s| "current sessions: #{s[:scur]}, maximum sessions: #{s[:smax]} for #{s[:pxname]} backend." }.join(', ')
       else
         ok status
       end

--- a/bin/check-haproxy.rb
+++ b/bin/check-haproxy.rb
@@ -82,12 +82,10 @@ class CheckHAProxy < Sensu::Plugin::Check::CLI
          description: 'Session Limit Critical Percent, default: 90'
   option :backend_session_warn_percent,
          short: '-b PERCENT',
-         default: 75,
          proc: proc(&:to_i),
          description: 'Per Backend Session Limit Warning Percent, default: 75'
   option :backend_session_crit_percent,
          short: '-B PERCENT',
-         default: 90,
          proc: proc(&:to_i),
          description: 'Per Backend Session Limit Critical Percent, default: 90'
   option :min_warn_count,
@@ -137,11 +135,17 @@ class CheckHAProxy < Sensu::Plugin::Check::CLI
       warning_sessions = services.select { |svc| svc[:slim].to_i > 0 && (100 * svc[:scur].to_f / svc[:slim].to_f) > config[:session_warn_percent] }
 
       critical_backends = services.select do |svc|
-        svc[:svname] == 'BACKEND' && svc[:slim].to_i > 0 && (100 * svc[:scur].to_f / svc[:slim].to_f) > config[:backend_session_crit_percent]
+        config[:backend_session_crit_percent] &&
+        svc[:svname] == 'BACKEND' &&
+        svc[:slim].to_i > 0 &&
+        (100 * svc[:scur].to_f / svc[:smax].to_f) > config[:backend_session_crit_percent]
       end
 
       warning_backends = services.select do |svc|
-        svc[:svname] == 'BACKEND' && svc[:slim].to_i > 0 && (100 * svc[:scur].to_f / svc[:slim].to_f) > config[:backend_session_warn_percent]
+        config[:backend_session_warn_percent] &&
+        svc[:svname] == 'BACKEND' &&
+        svc[:slim].to_i > 0 &&
+        (100 * svc[:scur].to_f / svc[:smax].to_f) > config[:backend_session_warn_percent]
       end
 
       status = "UP: #{percent_up}% of #{services.size} /#{config[:service]}/ services" + (failed_names.empty? ? '' : ", DOWN: #{failed_names.join(', ')}")

--- a/bin/check-haproxy.rb
+++ b/bin/check-haproxy.rb
@@ -83,11 +83,11 @@ class CheckHAProxy < Sensu::Plugin::Check::CLI
   option :backend_session_warn_percent,
          short: '-b PERCENT',
          proc: proc(&:to_i),
-         description: 'Per Backend Session Limit Warning Percent, default: 75'
+         description: 'Per Backend Session Limit Warning Percent'
   option :backend_session_crit_percent,
          short: '-B PERCENT',
          proc: proc(&:to_i),
-         description: 'Per Backend Session Limit Critical Percent, default: 90'
+         description: 'Per Backend Session Limit Critical Percent'
   option :min_warn_count,
          short: '-M COUNT',
          default: 0,

--- a/bin/check-haproxy.rb
+++ b/bin/check-haproxy.rb
@@ -82,13 +82,11 @@ class CheckHAProxy < Sensu::Plugin::Check::CLI
          description: 'Session Limit Critical Percent, default: 90'
   option :backend_session_warn_percent,
          short: '-b PERCENT',
-         boolean: true,
          default: 75,
          proc: proc(&:to_i),
          description: 'Per Backend Session Limit Warning Percent, default: 75'
   option :backend_session_crit_percent,
          short: '-B PERCENT',
-         boolean: true,
          default: 90,
          proc: proc(&:to_i),
          description: 'Per Backend Session Limit Critical Percent, default: 90'
@@ -154,7 +152,7 @@ class CheckHAProxy < Sensu::Plugin::Check::CLI
       elsif !critical_sessions.empty? && config[:backend_session_crit_percent].nil?
         critical status + '; Active sessions critical: ' + critical_sessions.map { |s| "#{s[:scur]} #{s[:pxname]}.#{s[:svname]}" }.join(', ')
       elsif config[:backend_session_crit_percent] && !critical_backends.empty?
-        critical status + '; Active Backends critical: ' +
+        critical status + '; Active backends critical: ' +
           critical_backends.map { |s| "current sessions: #{s[:scur]}, maximum sessions: #{s[:slim]} for #{s[:pxname]} backend." }.join(', ')
       elsif services.size < config[:min_warn_count]
         warning status
@@ -163,7 +161,7 @@ class CheckHAProxy < Sensu::Plugin::Check::CLI
       elsif !warning_sessions.empty? && config[:backend_session_warning_percent].nil?
         warning status + '; Active sessions warning: ' + warning_sessions.map { |s| "#{s[:scur]} #{s[:pxname]}.#{s[:svname]}" }.join(', ')
       elsif config[:backend_session_warn_percent] && !warning_backends.empty?
-        critical status + '; Active Backends warning: ' +
+        critical status + '; Active backends warning: ' +
           warning_backends.map { |s| "current sessions: #{s[:scur]}, maximum sessions: #{s[:slim]} for #{s[:pxname]} backend." }.join(', ')
       else
         ok status

--- a/lib/sensu-plugins-haproxy/version.rb
+++ b/lib/sensu-plugins-haproxy/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsHAProxy
   module Version
     MAJOR = 0
     MINOR = 0
-    PATCH = 5
+    PATCH = 6
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
-b and -B check for warning and critical levels of active sessions per backend and ignore counts per service. If -b is selected it ignores session_warn_percent flag and -B ignores session_crit_percent flag.
