### PR TITLE
Add a `num_up` metric for each backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+- added `num_up` metric for each backend set showing the number of available
+  backends.
+
 ## [0.0.5] - 2015-11-26
 ### Changed
 - alert on min server count


### PR DESCRIPTION
This adds an additional metric per monitored haproxy 'backend', eg:

```
servers.:::name:::.haproxy.main.num_up 0 1456358056
servers.:::name:::.haproxy.stats.num_up 0 1456358056
servers.:::name:::.haproxy.yggdrasil.num_up 64 1456358056
```

This has been very useful for a particular case where we have a large
number of backend procs that sometimes block or timeout and we want to
alert or graph the activity overtime.

Example graph with 64 backends, showing fluctuations as the backends become stressed and temporarily drop out of haproxy's available pool:

![image](https://cloud.githubusercontent.com/assets/377603/13305308/38f88ff4-db0f-11e5-91a5-d15c9e3ebf90.png)
