### PR TITLE
added session_current to output for server_metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [0.1.1] - 2016-04-22
+### Added
+- added session_current to output for server_metrics
+
 ## [0.1.0] - 2016-03-04
 ### Added
 - added `num_up` metric for each backend set showing the number of available backends

--- a/bin/metrics-haproxy.rb
+++ b/bin/metrics-haproxy.rb
@@ -175,6 +175,7 @@ class HAProxyMetrics < Sensu::Plugin::Metric::CLI::Graphite
         output "#{config[:scheme]}.#{line[0]}.average_time", line[61]
       elsif config[:server_metrics]
         output "#{config[:scheme]}.#{line[0]}.#{line[1]}.session_total", line[7]
+        output "#{config[:scheme]}.#{line[0]}.#{line[1]}.session_current", line[4]
       end
 
       if line[1] != 'BACKEND' && !line[1].nil?


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No - This request is to add current_sessions to the frontend metrics.
#### General
- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [ ] RuboCop passes
- [ ] Existing tests pass 
#### New Plugins
- [ ] Tests
- [ ] Add the plugin to the README
- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)
#### Purpose

This request is to add current_sessions to the frontend metrics.
#### Known Compatablity Issues

None
