### PR TITLE
Services without a health check should not be considered failed

### DIFF
--- a/bin/check-haproxy.rb
+++ b/bin/check-haproxy.rb
@@ -129,8 +129,8 @@ class CheckHAProxy < Sensu::Plugin::Check::CLI
         warning
       end
     else
-      percent_up = 100 * services.count { |svc| svc[:status] == 'UP' || svc[:status] == 'OPEN' } / services.size
-      failed_names = services.reject { |svc| svc[:status] == 'UP' || svc[:status] == 'OPEN' }.map { |svc| svc[:svname] }
+      percent_up = 100 * services.count { |svc| svc[:status] == 'UP' || svc[:status] == 'OPEN' || svc[:status] == 'no check' } / services.size
+      failed_names = services.reject { |svc| svc[:status] == 'UP' || svc[:status] == 'OPEN' || svc[:status] == 'no check' }.map { |svc| svc[:svname] }
       critical_sessions = services.select { |svc| svc[:slim].to_i > 0 && (100 * svc[:scur].to_f / svc[:slim].to_f) > config[:session_crit_percent] }
       warning_sessions = services.select { |svc| svc[:slim].to_i > 0 && (100 * svc[:scur].to_f / svc[:slim].to_f) > config[:session_warn_percent] }
 


### PR DESCRIPTION
The status 'no check' means there is no defined health check and the service status is unknown.  Since HAProxy is not tracking the state of the service it should not be considered failed.
