### PR TITLE
Add names of the failed backends to check-haproxy.rb status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- added names of the failed backends to check-haproxy.rb status
 
 ## [0.1.1] - 2016-04-23
 ### Added

--- a/bin/check-haproxy.rb
+++ b/bin/check-haproxy.rb
@@ -130,7 +130,7 @@ class CheckHAProxy < Sensu::Plugin::Check::CLI
       end
     else
       percent_up = 100 * services.count { |svc| svc[:status] == 'UP' || svc[:status] == 'OPEN' || svc[:status] == 'no check' } / services.size
-      failed_names = services.reject { |svc| svc[:status] == 'UP' || svc[:status] == 'OPEN' || svc[:status] == 'no check' }.map { |svc| svc[:svname] }
+      failed_names = services.reject { |svc| svc[:status] == 'UP' || svc[:status] == 'OPEN' || svc[:status] == 'no check' }.map { |svc| "#{svc[:pxname]}/#{svc[:svname]}" }
       critical_sessions = services.select { |svc| svc[:slim].to_i > 0 && (100 * svc[:scur].to_f / svc[:slim].to_f) > config[:session_crit_percent] }
       warning_sessions = services.select { |svc| svc[:slim].to_i > 0 && (100 * svc[:scur].to_f / svc[:slim].to_f) > config[:session_warn_percent] }
 

--- a/bin/check-haproxy.rb
+++ b/bin/check-haproxy.rb
@@ -130,7 +130,9 @@ class CheckHAProxy < Sensu::Plugin::Check::CLI
       end
     else
       percent_up = 100 * services.count { |svc| svc[:status] == 'UP' || svc[:status] == 'OPEN' || svc[:status] == 'no check' } / services.size
-      failed_names = services.reject { |svc| svc[:status] == 'UP' || svc[:status] == 'OPEN' || svc[:status] == 'no check' }.map { |svc| "#{svc[:pxname]}/#{svc[:svname]}" }
+      failed_names = services.reject { |svc| svc[:status] == 'UP' || svc[:status] == 'OPEN' || svc[:status] == 'no check' }.map do |svc|
+        "#{svc[:pxname]}/#{svc[:svname]}"
+      end
       critical_sessions = services.select { |svc| svc[:slim].to_i > 0 && (100 * svc[:scur].to_f / svc[:slim].to_f) > config[:session_crit_percent] }
       warning_sessions = services.select { |svc| svc[:slim].to_i > 0 && (100 * svc[:scur].to_f / svc[:slim].to_f) > config[:session_warn_percent] }
 


### PR DESCRIPTION
## Pull Request Checklist
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 
#### New Plugins
- [ ] Tests
- [ ] Add the plugin to the README
- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)
#### Purpose

When `-s` matches multiple services on multiple nodes then status with `svname` only is not enough to distinguish which one is failing:

```
# check-haproxy.rb --stats localhost --port 8000 --statspath __haproxy_stats -w 100 -c 98 -s 'app'
CheckHAProxy WARNING: UP: 98% of 50 /app/ services, DOWN: node1.local
```

With `pxname` added to status its clear:

```
# check-haproxy.rb --stats localhost --port 8000 --statspath __haproxy_stats -w 100 -c 98 -s 'app'
CheckHAProxy WARNING: UP: 98% of 50 /app/ services, DOWN: app1/node1.local
```
#### Known Compatablity Issues
