### PR TITLE
Add check status of failed backends to check-haproxy.rb output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Changed
 - added names of the failed backends to check-haproxy.rb status
+- added check status of failed backends to check-haproxy.rb output
 
 ## [0.1.1] - 2016-04-23
 ### Added

--- a/bin/check-haproxy.rb
+++ b/bin/check-haproxy.rb
@@ -131,7 +131,7 @@ class CheckHAProxy < Sensu::Plugin::Check::CLI
     else
       percent_up = 100 * services.count { |svc| svc[:status] == 'UP' || svc[:status] == 'OPEN' || svc[:status] == 'no check' } / services.size
       failed_names = services.reject { |svc| svc[:status] == 'UP' || svc[:status] == 'OPEN' || svc[:status] == 'no check' }.map do |svc|
-        "#{svc[:pxname]}/#{svc[:svname]}"
+        "#{svc[:pxname]}/#{svc[:svname]}#{svc[:check_status].to_s.empty? ? '' : '[' + svc[:check_status] + ']'}"
       end
       critical_sessions = services.select { |svc| svc[:slim].to_i > 0 && (100 * svc[:scur].to_f / svc[:slim].to_f) > config[:session_crit_percent] }
       warning_sessions = services.select { |svc| svc[:slim].to_i > 0 && (100 * svc[:scur].to_f / svc[:slim].to_f) > config[:session_warn_percent] }


### PR DESCRIPTION
This should make it easier to identify source of the problem more quickly and to see if it is changing.
