### PR TITLE
Consider "going down" backup as still UP.

### DIFF
--- a/bin/check-haproxy.rb
+++ b/bin/check-haproxy.rb
@@ -129,8 +129,8 @@ class CheckHAProxy < Sensu::Plugin::Check::CLI
         warning
       end
     else
-      percent_up = 100 * services.count { |svc| svc[:status] == 'UP' || svc[:status] == 'OPEN' || svc[:status] == 'no check' } / services.size
-      failed_names = services.reject { |svc| svc[:status] == 'UP' || svc[:status] == 'OPEN' || svc[:status] == 'no check' }.map do |svc|
+      percent_up = 100 * services.count { |svc| svc[:status].start_with?('UP') || svc[:status] == 'OPEN' || svc[:status] == 'no check' } / services.size
+      failed_names = services.reject { |svc| svc[:status].start_with?('UP') || svc[:status] == 'OPEN' || svc[:status] == 'no check' }.map do |svc|
         "#{svc[:pxname]}/#{svc[:svname]}#{svc[:check_status].to_s.empty? ? '' : '[' + svc[:check_status] + ']'}"
       end
       critical_sessions = services.select { |svc| svc[:slim].to_i > 0 && (100 * svc[:scur].to_f / svc[:slim].to_f) > config[:session_crit_percent] }

--- a/bin/metrics-haproxy.rb
+++ b/bin/metrics-haproxy.rb
@@ -180,7 +180,7 @@ class HAProxyMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
       if line[1] != 'BACKEND' && !line[1].nil?
         up_by_backend[line[0]] ||= 0
-        up_by_backend[line[0]] += (line[17] == 'UP') ? 1 : 0
+        up_by_backend[line[0]] += line[17].start_with?('UP') ? 1 : 0
       end
     end
 


### PR DESCRIPTION
When backend is going down (i.e. healthcking has not reached a "fall"
threshold yet), its status becomes "UP x/x" [1] rathen than UP. We should
consider this status the same as UP since what is the point of
healthcheck configuration then.

[1] https://github.com/haproxy/haproxy/blob/master/src/stats.c#L1224

