### PR TITLE
Add frontend request rate metrics to --server-metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - Ruby 2.4.1 testing
+- Frontend request rate metrics to `--server-metrics`
 
 ## [1.1.0] - 2017-01-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - Ruby 2.4.1 testing
-- Frontend request rate metrics to `--server-metrics`
+- Add frontend request rate metrics to `--server-metrics`
 
 ## [1.1.0] - 2017-01-30
 ### Added

--- a/bin/metrics-haproxy.rb
+++ b/bin/metrics-haproxy.rb
@@ -176,6 +176,9 @@ class HAProxyMetrics < Sensu::Plugin::Metric::CLI::Graphite
       elsif config[:server_metrics]
         output "#{config[:scheme]}.#{line[0]}.#{line[1]}.session_total", line[7]
         output "#{config[:scheme]}.#{line[0]}.#{line[1]}.session_current", line[4]
+        output "#{config[:scheme]}.#{line[0]}.#{line[1]}.requests_per_second", line[46]
+        output "#{config[:scheme]}.#{line[0]}.#{line[1]}.requests_per_second_max", line[47]
+        output "#{config[:scheme]}.#{line[0]}.#{line[1]}.requests_total", line[48]
       end
 
       if line[1] != 'BACKEND' && !line[1].nil?

--- a/bin/metrics-haproxy.rb
+++ b/bin/metrics-haproxy.rb
@@ -83,7 +83,7 @@ class HAProxyMetrics < Sensu::Plugin::Metric::CLI::Graphite
          default: [] # an empty list means show all backends
 
   option :server_metrics,
-         description: 'Add metrics for backend servers',
+         description: 'Gathers additional frontend metrics, i.e. total requests',
          boolean: true,
          long: '--server-metrics',
          default: false


### PR DESCRIPTION
## Pull Request Checklist

RE https://github.com/sensu-plugins/sensu-plugins-haproxy/issues/22

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

As per linked issue there are currently some frontend metrics that are not collected as part of the `--server-metrics` config option that would prove useful for plugin users.

This change adds metrics for requests per second, max requests per second & total requests.

#### Known Compatability Issues

n/a

