### PR TITLE
Add config flag to use SSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 
 ## [Unreleased]
+### Added
+- Flag to use SSL in `check-haproxy.rb``
 
 ## [1.2.0] - 2017-07-25
 ### Added

--- a/bin/check-haproxy.rb
+++ b/bin/check-haproxy.rb
@@ -56,6 +56,11 @@ class CheckHAProxy < Sensu::Plugin::Check::CLI
          short: '-p PASSWORD',
          long: '--pass PASSWORD',
          description: 'HAproxy web stats password'
+  option :use_ssl,
+         description: 'Use SSL to connect to HAproxy web stats',
+         long: '--use-ssl',
+         boolean: true,
+         default: false
   option :warn_percent,
          short: '-w PERCENT',
          boolean: true,
@@ -201,7 +206,7 @@ class CheckHAProxy < Sensu::Plugin::Check::CLI
       out = srv.read
       srv.close
     else
-      res = Net::HTTP.start(config[:stats_source], config[:port]) do |http|
+      res = Net::HTTP.start(config[:stats_source], config[:port], use_ssl: config[:use_ssl]) do |http|
         req = Net::HTTP::Get.new("/#{config[:path]};csv;norefresh")
         unless config[:username].nil?
           req.basic_auth config[:username], config[:password]


### PR DESCRIPTION
## Pull Request Checklist

RE https://github.com/sensu-plugins/sensu-plugins-haproxy/issues/12

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

As per linked issue `check-haproxy.rb` does not currently provide an option to use SSL, unlike `metrics-haproxy.rb` which already does.

This change copies the implementation found in `metrics-haproxy.rb`

#### Known Compatability Issues

None, SSL is disabled by default.
