### PR TITLE
Update check-haproxy.rb

### DIFF
--- a/bin/check-haproxy.rb
+++ b/bin/check-haproxy.rb
@@ -178,7 +178,7 @@ class CheckHAProxy < Sensu::Plugin::Check::CLI
       elsif percent_up < config[:crit_percent]
         critical status
       elsif !critical_sessions.empty? && config[:backend_session_crit_percent].nil?
-        critical status + '; Active sessions critical: ' + critical_sessions.map { |s| "#{s[:scur]} #{s[:pxname]}.#{s[:svname]}" }.join(', ')
+        critical status + '; Active sessions critical: ' + critical_sessions.map { |s| "#{s[:scur]} of #{s[:slim]} #{s[:pxname]}.#{s[:svname]}" }.join(', ')
       elsif config[:backend_session_crit_percent] && !critical_backends.empty?
         critical status + '; Active backends critical: ' +
                  critical_backends.map { |s| "current sessions: #{s[:scur]}, maximum sessions: #{s[:smax]} for #{s[:pxname]} backend." }.join(', ')
@@ -187,7 +187,7 @@ class CheckHAProxy < Sensu::Plugin::Check::CLI
       elsif percent_up < config[:warn_percent]
         warning status
       elsif !warning_sessions.empty? && config[:backend_session_warn_percent].nil?
-        warning status + '; Active sessions warning: ' + warning_sessions.map { |s| "#{s[:scur]} #{s[:pxname]}.#{s[:svname]}" }.join(', ')
+        warning status + '; Active sessions warning: ' + warning_sessions.map { |s| "#{s[:scur]} of #{s[:slim]} #{s[:pxname]}.#{s[:svname]}" }.join(', ')
       elsif config[:backend_session_warn_percent] && !warning_backends.empty?
         critical status + '; Active backends warning: ' +
                  warning_backends.map { |s| "current sessions: #{s[:scur]}, maximum sessions: #{s[:smax]} for #{s[:pxname]} backend." }.join(', ')


### PR DESCRIPTION
Extended sessions warning and critical output to also show sessions limit.

Old output:
`CheckHAProxy CRITICAL: UP: 100% of 10 // services; Active sessions critical: 10684 web.BACKEND`

New output:
`CheckHAProxy CRITICAL: UP: 100% of 10 // services; Active sessions critical: 10684 of 15000 web.BACKEND`

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
